### PR TITLE
[fix] Change MqttCocoaAsyncSocket Reference

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "MqttCocoaAsyncSocket",
-        "repositoryURL": "https://github.com/leeway1208/MqttCocoaAsyncSocket",
-        "state": {
-          "branch": null,
-          "revision": "ce3e18607fd01079495f86ff6195d8a3ca469f73",
-          "version": "1.0.8"
-        }
-      },
-      {
-        "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
-        "state": {
-          "branch": null,
-          "revision": "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
-          "version": "4.0.8"
-        }
+  "pins" : [
+    {
+      "identity" : "mqttcocoaasyncsocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/worksmobile/MqttCocoaAsyncSocket",
+      "state" : {
+        "branch" : "1.0.8.1-RC1",
+        "revision" : "ba624edcdd79edf1432d5393fedc19f6477371bb"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream.git",
+      "state" : {
+        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+        "version" : "4.0.8"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,15 +8,15 @@ let package = Package(
     platforms: [
         .macOS(.v10_13),
         .iOS(.v12),
-        .tvOS(.v10)
+        .tvOS(.v12)
     ],
     products: [
         .library(name: "CocoaMQTT", targets: [ "CocoaMQTT" ]),
         .library(name: "CocoaMQTTWebSocket", targets: [ "CocoaMQTTWebSocket" ])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream.git", .exact("4.0.8")),
-        .package(url: "https://github.com/leeway1208/MqttCocoaAsyncSocket", from: "1.0.8"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.8"),
+        .package(url: "https://github.com/worksmobile/MqttCocoaAsyncSocket", revision: "1.0.8.1-RC1"),
     ],
     targets: [
         .target(name: "CocoaMQTT",


### PR DESCRIPTION
## Issue

- https://github.com/leeway1208/MqttCocoaAsyncSocket is no longer updated

## Changes

- Change reference into forked repository
  - https://github.com/worksmobile/MqttCocoaAsyncSocket
- Change the version of swift package manager into 5.7
  - Fix some grammers

## References

- https://github.com/worksmobile/MqttCocoaAsyncSocket/pull/1