### PR TITLE
[fix] Could not reconnect after manual disconnection

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -612,6 +612,7 @@ extension CocoaMQTT: CocoaMQTTSocketDelegate {
         didDisconnect(self, err)
 
         guard !is_internal_disconnected else {
+            is_internal_disconnected = false
             return
         }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -669,6 +669,7 @@ extension CocoaMQTT5: CocoaMQTTSocketDelegate {
         didDisconnect(self, err)
 
         guard !is_internal_disconnected else {
+            is_internal_disconnected = false
             return
         }
 


### PR DESCRIPTION
## Issues

- Could not reconnect after manual disconnection

## Causes

- is_internal_disconnected is not reset.

## Changes

-  After a manual disconnection, is_internal_disconnected should be reset.

## Reference

- https://github.com/emqx/CocoaMQTT/pull/608/files